### PR TITLE
pr(consensus/state): fix test fail and refactor

### DIFF
--- a/src/noir/consensus/store/block_store.h
+++ b/src/noir/consensus/store/block_store.h
@@ -203,8 +203,8 @@ public:
     auto height_ = bl.header.height;
     auto hash_ = const_cast<block&>(bl).get_hash();
     auto parts_ = const_cast<part_set&>(bl_parts);
-    assert((base() == 0) || (height_ == height() + 1)); // TODO: might need reserve() to optimize
-    assert(parts_.is_complete()); // TODO: might need reserve() to optimize
+    assert((base() == 0) || (height_ == height() + 1)); // TODO: handle panic in consensus
+    assert(parts_.is_complete()); // TODO: handle panic in consensus
 
     // Save block parts. This must be done before the block meta, since callers
     // typically load the block meta first as an indication that the block exists

--- a/src/noir/consensus/store/block_store.h
+++ b/src/noir/consensus/store/block_store.h
@@ -130,7 +130,7 @@ public:
     if (!tmp.has_value()) {
       return false;
     }
-    auto height_ = noir::codec::scale::decode<int64_t>(tmp.value());
+    auto height_ = decode_val(tmp.value());
     return load_block(height_, bl);
   }
 
@@ -329,9 +329,14 @@ private:
 
   std::shared_ptr<db_session_type> db_session_;
 
-  static bytes encode_val(int64_t val) {
+  static inline bytes encode_val(int64_t val) {
     auto hex_ = from_hex(fmt::format("{:016x}", static_cast<uint64_t>(val)));
     return {hex_.begin(), hex_.end()};
+  }
+
+  static inline int64_t decode_val(bytes buf) {
+    auto height_hex = to_hex(buf);
+    return stoull(height_hex, nullptr, 16);
   }
 
   template<typename... int64s>
@@ -380,8 +385,7 @@ private:
       return false;
     }
 
-    auto height_hex = to_hex(bytes{key.begin() + 1, key.end()});
-    height_ = stoull(height_hex, nullptr, 16);
+    height_ = decode_val(bytes{key.begin() + 1, key.end()});
     return true;
   }
 

--- a/src/noir/consensus/store/block_store_test.cpp
+++ b/src/noir/consensus/store/block_store_test.cpp
@@ -94,6 +94,7 @@ TEST_CASE("save/load_block", "[block_store]") {
   noir::consensus::commit commit_{};
   for (auto height = 1; height < 100; ++height) {
     auto bl_ = make_block(height, genesis_state, commit_);
+    auto hash_ = bl_.get_hash(); // TODO: temporary workaround (block get_hash() not implemented)
     auto p_set_ = make_part_set(bl_, 2);
     auto seen_commit_ = make_commit(10, noir::p2p::tstamp{});
 
@@ -132,9 +133,9 @@ TEST_CASE("save/load_block", "[block_store]") {
 
     {
       // TODO: bl.get_hash()
-      // noir::consensus::block ret{};
-      // noir::consensus::block exp{};
-      // CHECK(bls.load_block_by_hash(exp.get_hash(), ret) == true);
+      noir::consensus::block ret{};
+      CHECK(bls.load_block_by_hash(hash_, ret) == true);
+      CHECK(ret.get_hash() == bl_.get_hash());
     }
 
     {

--- a/src/noir/consensus/store/store_test.h
+++ b/src/noir/consensus/store/store_test.h
@@ -33,12 +33,7 @@ inline noir::db::session::session<noir::db::session::rocksdb_t> make_session(con
 }
 
 inline noir::bytes gen_random_bytes(size_t num) {
-  noir::bytes ret{};
-  std::random_device rd;
-  std::uniform_int_distribution<int> dist(0, 255);
-
-  for (auto i = 0; i < num; ++i) {
-    ret.push_back(dist(rd) & 0xff);
-  }
+  noir::bytes ret(num);
+  fc::rand_pseudo_bytes(ret.data(), ret.size());
   return ret;
 }


### PR DESCRIPTION
following commits are included in this pr
- fix test fail in block_store_test due to uninitialized hash bytes in block
- change gen_random_bytes() internal logic using from std::uniform_int_distribution to fc::rand_pseudo_bytes