### PR TITLE
fix(crypto/sha256): crash on sha256 init

### DIFF
--- a/src/noir/crypto/openssl.h
+++ b/src/noir/crypto/openssl.h
@@ -32,7 +32,7 @@ struct hash : public crypto::hash {
   virtual const EVP_MD* type() = 0;
 
 protected:
-  EVP_MD_CTX* ctx;
+  EVP_MD_CTX* ctx = nullptr;
 };
 
 } // namespace noir::openssl


### PR DESCRIPTION
crypto hash function consists of init()->update()->final()
during init(), struct for functor was initialized
but not with internal ptr and may results in crash.
This commit fix it.