### PR TITLE
feat(consensus): add feature file_priv_validator

### DIFF
--- a/src/noir/common/CMakeLists.txt
+++ b/src/noir/common/CMakeLists.txt
@@ -10,3 +10,4 @@ target_sources(noir
 add_noir_test(bytes_test test/bytes_test.cpp)
 add_noir_test(check_test test/check_test.cpp)
 add_noir_test(varint_test types/test/varint_test.cpp)
+add_noir_test(helper_test helper/test/variant_test.cpp)

--- a/src/noir/common/helper/test/variant_test.cpp
+++ b/src/noir/common/helper/test/variant_test.cpp
@@ -189,8 +189,8 @@ TEMPLATE_TEST_CASE("variant: to/from_variant", "[noir][common]", signed_integral
 
   fc::variant tmp;
   TestType ret;
-  noir::to_variant(exp, tmp);
-  noir::from_variant(tmp, ret);
+  fc::to_variant(exp, tmp);
+  fc::from_variant(tmp, ret);
   CHECK(exp == ret);
 }
 

--- a/src/noir/common/helper/test/variant_test.cpp
+++ b/src/noir/common/helper/test/variant_test.cpp
@@ -1,0 +1,197 @@
+// This file is part of NOIR.
+//
+// Copyright (c) 2022 Haderech Pte. Ltd.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+#include <catch2/catch_all.hpp>
+#include <noir/common/concepts.h>
+#include <noir/common/refl.h>
+
+struct signed_integral_type {
+  int8_t a = 0xf;
+  int16_t b = 0xff;
+  int32_t c = 0xffff;
+  int64_t d = 0xffffffffll;
+
+  bool operator==(const signed_integral_type& o) const {
+    return (a == o.a) && (b == o.b) && (c == o.c) && (d == o.d);
+  }
+};
+NOIR_REFLECT(signed_integral_type, a, b, c, d)
+
+struct unsigned_integral_type {
+  uint8_t a = 0xf;
+  uint16_t b = 0xff;
+  uint32_t c = 0xffff;
+  uint64_t d = 0xffffffffll;
+
+  bool operator==(const unsigned_integral_type& o) const {
+    return (a == o.a) && (b == o.b) && (c == o.c) && (d == o.d);
+  }
+};
+NOIR_REFLECT(unsigned_integral_type, a, b, c, d)
+
+struct complex_integral_type {
+  signed_integral_type a;
+  signed_integral_type b;
+  unsigned_integral_type c;
+  unsigned_integral_type d;
+
+  bool operator==(const complex_integral_type& o) const {
+    return (a == o.a) && (b == o.b) && (c == o.c) && (d == o.d);
+  }
+};
+NOIR_REFLECT(complex_integral_type, a, b, c, d)
+
+enum class signed_enum_8 : int8_t {
+  // workaround clang-format
+  a = 0xf,
+};
+enum class signed_enum_16 : int16_t {
+  // workaround clang-format
+  b = 0xff,
+};
+enum class signed_enum_32 : int32_t {
+  // workaround clang-format
+  c = 0xffff,
+};
+enum class signed_enum_64 : int64_t {
+  // workaround clang-format
+  d = 0xffffffffll,
+};
+struct signed_enumeration_type {
+  signed_enum_8 a = signed_enum_8::a;
+  signed_enum_16 b = signed_enum_16::b;
+  signed_enum_32 c = signed_enum_32::c;
+  signed_enum_64 d = signed_enum_64::d;
+
+  bool operator==(const signed_enumeration_type& o) const {
+    return (a == o.a) && (b == o.b) && (c == o.c) && (d == o.d);
+  }
+};
+NOIR_REFLECT(signed_enumeration_type, a, b, c, d)
+
+enum class unsigned_enum_8 : int8_t {
+  // workaround clang-format
+  a = 0xf,
+};
+enum class unsigned_enum_16 : int16_t {
+  // workaround clang-format
+  b = 0xff,
+};
+enum class unsigned_enum_32 : int32_t {
+  // workaround clang-format
+  c = 0xffff,
+};
+enum class unsigned_enum_64 : int64_t {
+  // workaround clang-format
+  d = 0xffffffffll,
+};
+struct unsigned_enumeration_type {
+  unsigned_enum_8 a = unsigned_enum_8::a;
+  unsigned_enum_16 b = unsigned_enum_16::b;
+  unsigned_enum_32 c = unsigned_enum_32::c;
+  unsigned_enum_64 d = unsigned_enum_64::d;
+
+  bool operator==(const unsigned_enumeration_type& o) const {
+    return (a == o.a) && (b == o.b) && (c == o.c) && (d == o.d);
+  }
+};
+NOIR_REFLECT(unsigned_enumeration_type, a, b, c, d)
+
+struct complex_enumeration_type {
+  signed_enumeration_type a;
+  signed_enumeration_type b;
+  unsigned_enumeration_type c;
+  unsigned_enumeration_type d;
+
+  bool operator==(const complex_enumeration_type& o) const {
+    return (a == o.a) && (b == o.b) && (c == o.c) && (d == o.d);
+  }
+};
+NOIR_REFLECT(complex_enumeration_type, a, b, c, d)
+
+struct complex_any_type {
+  complex_integral_type a;
+  complex_enumeration_type b;
+  complex_integral_type c;
+  complex_integral_type d;
+
+  bool operator==(const complex_any_type& o) const {
+    return (a == o.a) && (b == o.b) && (c == o.c) && (d == o.d);
+  }
+};
+NOIR_REFLECT(complex_any_type, a, b, c, d)
+
+struct vector_integral_type {
+  std::vector<int8_t> a;
+  std::vector<int16_t> b;
+  std::vector<int32_t> c;
+  std::vector<int64_t> d;
+
+  vector_integral_type() {
+    a.resize(10);
+    b.resize(10);
+    c.resize(10);
+    d.resize(10);
+  }
+  bool operator==(const vector_integral_type& o) const {
+    return (a == o.a) && (b == o.b) && (c == o.c) && (d == o.d);
+  }
+};
+NOIR_REFLECT(vector_integral_type, a, b, c, d);
+
+// struct vector_enumeration_type {
+//   std::vector<signed_enum_8> a;
+//   std::vector<signed_enum_16> b;
+//   std::vector<signed_enum_32> c;
+//   std::vector<signed_enum_64> d;
+//
+//   vector_enumeration_type() {
+//     a.resize(10);
+//     b.resize(10);
+//     c.resize(10);
+//     d.resize(10);
+//   }
+//   bool operator==(const vector_enumeration_type& o) const {
+//     return (a == o.a) && (b == o.b) && (c == o.c) && (d == o.d);
+//   }
+// };
+// NOIR_REFLECT(vector_enumeration_type, a, b, c, d);
+//
+// struct complex_vector_type {
+//   std::vector<complex_integral_type> a;
+//   std::vector<complex_enumeration_type> b;
+//   std::vector<vector_integral_type> c;
+//   std::vector<vector_enumeration_type> d;
+//
+//   complex_vector_type() {
+//     a.resize(10);
+//     b.resize(10);
+//     c.resize(10);
+//     d.resize(10);
+//   }
+//   bool operator==(const complex_vector_type& o) const {
+//     return (a == o.a) && (b == o.b) && (c == o.c) && (d == o.d);
+//   }
+// };
+// NOIR_REFLECT(complex_vector_type, a, b, c, d)
+
+#include <noir/common/helper/variant.h>
+
+namespace {
+
+TEMPLATE_TEST_CASE("variant: to/from_variant", "[noir][common]", signed_integral_type, unsigned_integral_type,
+  complex_integral_type, signed_enumeration_type, unsigned_enumeration_type, complex_enumeration_type,
+  complex_any_type /* , vector_enumeration_type, complex_vector_type */) {
+
+  TestType exp{};
+
+  fc::variant tmp;
+  TestType ret;
+  noir::to_variant(exp, tmp);
+  noir::from_variant(tmp, ret);
+  CHECK(exp == ret);
+}
+
+} // namespace

--- a/src/noir/common/helper/test/variant_test.cpp
+++ b/src/noir/common/helper/test/variant_test.cpp
@@ -111,17 +111,17 @@ struct complex_enumeration_type {
 };
 NOIR_REFLECT(complex_enumeration_type, a, b, c, d)
 
-struct complex_any_type {
+struct nested_complex_type {
   complex_integral_type a;
   complex_enumeration_type b;
   complex_integral_type c;
   complex_integral_type d;
 
-  bool operator==(const complex_any_type& o) const {
+  bool operator==(const nested_complex_type& o) const {
     return (a == o.a) && (b == o.b) && (c == o.c) && (d == o.d);
   }
 };
-NOIR_REFLECT(complex_any_type, a, b, c, d)
+NOIR_REFLECT(nested_complex_type, a, b, c, d)
 
 struct vector_integral_type {
   std::vector<int8_t> a;
@@ -141,41 +141,41 @@ struct vector_integral_type {
 };
 NOIR_REFLECT(vector_integral_type, a, b, c, d);
 
-// struct vector_enumeration_type {
-//   std::vector<signed_enum_8> a;
-//   std::vector<signed_enum_16> b;
-//   std::vector<signed_enum_32> c;
-//   std::vector<signed_enum_64> d;
-//
-//   vector_enumeration_type() {
-//     a.resize(10);
-//     b.resize(10);
-//     c.resize(10);
-//     d.resize(10);
-//   }
-//   bool operator==(const vector_enumeration_type& o) const {
-//     return (a == o.a) && (b == o.b) && (c == o.c) && (d == o.d);
-//   }
-// };
-// NOIR_REFLECT(vector_enumeration_type, a, b, c, d);
-//
-// struct complex_vector_type {
-//   std::vector<complex_integral_type> a;
-//   std::vector<complex_enumeration_type> b;
-//   std::vector<vector_integral_type> c;
-//   std::vector<vector_enumeration_type> d;
-//
-//   complex_vector_type() {
-//     a.resize(10);
-//     b.resize(10);
-//     c.resize(10);
-//     d.resize(10);
-//   }
-//   bool operator==(const complex_vector_type& o) const {
-//     return (a == o.a) && (b == o.b) && (c == o.c) && (d == o.d);
-//   }
-// };
-// NOIR_REFLECT(complex_vector_type, a, b, c, d)
+struct vector_enumeration_type {
+  std::vector<signed_enum_8> a;
+  std::vector<signed_enum_16> b;
+  std::vector<signed_enum_32> c;
+  std::vector<signed_enum_64> d;
+
+  vector_enumeration_type() {
+    a.resize(10);
+    b.resize(10);
+    c.resize(10);
+    d.resize(10);
+  }
+  bool operator==(const vector_enumeration_type& o) const {
+    return (a == o.a) && (b == o.b) && (c == o.c) && (d == o.d);
+  }
+};
+NOIR_REFLECT(vector_enumeration_type, a, b, c, d);
+
+struct complex_vector_type {
+  std::vector<complex_integral_type> a;
+  std::vector<complex_enumeration_type> b;
+  std::vector<vector_integral_type> c;
+  std::vector<vector_enumeration_type> d;
+
+  complex_vector_type() {
+    a.resize(10);
+    b.resize(10);
+    c.resize(10);
+    d.resize(10);
+  }
+  bool operator==(const complex_vector_type& o) const {
+    return (a == o.a) && (b == o.b) && (c == o.c) && (d == o.d);
+  }
+};
+NOIR_REFLECT(complex_vector_type, a, b, c, d)
 
 #include <noir/common/helper/variant.h>
 
@@ -183,7 +183,7 @@ namespace {
 
 TEMPLATE_TEST_CASE("variant: to/from_variant", "[noir][common]", signed_integral_type, unsigned_integral_type,
   complex_integral_type, signed_enumeration_type, unsigned_enumeration_type, complex_enumeration_type,
-  complex_any_type /* , vector_enumeration_type, complex_vector_type */) {
+  nested_complex_type, vector_enumeration_type, complex_vector_type) {
 
   TestType exp{};
 

--- a/src/noir/common/helper/variant.h
+++ b/src/noir/common/helper/variant.h
@@ -7,74 +7,40 @@
 #include <noir/common/check.h>
 #include <noir/common/concepts.h>
 #include <noir/common/refl.h>
-#include <fc/variant_object.hpp>
+#include <fc/reflect/variant.hpp>
 
-namespace noir {
+namespace fc {
 
-template<typename T>
-void to_named_variant(const T& in, const auto& name, fc::variant& out) {
-  out = fc::variant{in};
+template<noir::enumeration E>
+void to_variant(const E& in, variant& out) {
+  auto tmp = static_cast<std::underlying_type_t<E>>(in);
+  if constexpr (requires(const E& in) { variant(tmp); }) {
+    out = tmp;
+  } else {
+    to_variant(tmp, out);
+  }
 }
 
-template<enumeration E>
-void to_named_variant(const E& in, const auto& name, fc::variant& out) {
-  out = fc::variant{static_cast<std::underlying_type_t<E>>(in)};
-}
-
-template<reflection T>
-void to_named_variant(const T& in, const auto& name, fc::variant& out) {
-  fc::mutable_variant_object obj;
-  refl::for_each_field(
-    [&](const auto& name_, const auto& value) {
-      fc::variant var;
-      noir::to_named_variant(value, name_, var);
-      obj.set(std::string(name_), var);
-    },
-    in);
+template<noir::reflection T>
+void to_variant(const T& in, variant& out) {
+  mutable_variant_object obj;
+  noir::refl::for_each_field(
+    [&](const auto& name, const auto& value) { obj.set(std::string(name), variant{value}); }, in);
   out = obj;
 }
 
-template<reflection T>
-void to_variant(const T& in, fc::variant& out) {
-  fc::mutable_variant_object obj;
-  refl::for_each_field(
-    [&](const auto& name, const auto& value) {
-      fc::variant var;
-      noir::to_named_variant(value, name, var);
-      obj.set(std::string(name), var);
-    },
-    in);
-  out = obj;
-}
-
-template<typename T>
-void from_named_variant(const fc::variant& in, const auto& name, T& out) {
-  check(!in.is_object());
-  from_variant(in, out);
-}
-
-template<enumeration E>
-void from_named_variant(const fc::variant& in, const auto& name, E& out) {
-  check(!in.is_object());
+template<noir::enumeration E>
+void from_variant(const variant& in, E& out) {
   std::underlying_type_t<E> tmp;
   from_variant(in, tmp);
   out = static_cast<E>(tmp);
 }
 
-template<reflection T>
-void from_named_variant(const fc::variant& in, const auto& name, T& out) {
-  check(in.is_object());
+template<noir::reflection T>
+void from_variant(const variant& in, T& out) {
+  noir::check(in.is_object());
   auto obj = in.get_object();
-  refl::for_each_field(
-    [&](const auto& name_, auto& value) { from_named_variant(obj[std::string(name_)], name_, value); }, out);
+  noir::refl::for_each_field([&](const auto& name, auto& value) { from_variant(obj[std::string(name)], value); }, out);
 }
 
-template<reflection T>
-void from_variant(const fc::variant& in, T& out) {
-  check(in.is_object());
-  auto obj = in.get_object();
-  refl::for_each_field(
-    [&](const auto& name, auto& value) { from_named_variant(obj[std::string(name)], name, value); }, out);
-}
-
-} // namespace noir
+} // namespace fc

--- a/src/noir/common/helper/variant.h
+++ b/src/noir/common/helper/variant.h
@@ -11,21 +11,29 @@
 
 namespace fc {
 
+inline void to_variant(const int64_t& in, variant& out) {
+  out = in;
+}
+
+inline void to_variant(const uint64_t& in, variant& out) {
+  out = in;
+}
+
 template<noir::enumeration E>
 void to_variant(const E& in, variant& out) {
-  auto tmp = static_cast<std::underlying_type_t<E>>(in);
-  if constexpr (requires(const E& in) { variant(tmp); }) {
-    out = tmp;
-  } else {
-    to_variant(tmp, out);
-  }
+  to_variant(static_cast<std::underlying_type_t<E>>(in), out);
 }
 
 template<noir::reflection T>
 void to_variant(const T& in, variant& out) {
   mutable_variant_object obj;
   noir::refl::for_each_field(
-    [&](const auto& name, const auto& value) { obj.set(std::string(name), variant{value}); }, in);
+    [&](const auto& name, const auto& value) {
+      fc::variant var;
+      to_variant(value, var);
+      obj.set(std::string(name), var);
+    },
+    in);
   out = obj;
 }
 

--- a/src/noir/common/helper/variant.h
+++ b/src/noir/common/helper/variant.h
@@ -5,23 +5,76 @@
 //
 #pragma once
 #include <noir/common/check.h>
+#include <noir/common/concepts.h>
 #include <noir/common/refl.h>
 #include <fc/variant_object.hpp>
 
 namespace noir {
 
+template<typename T>
+void to_named_variant(const T& in, const auto& name, fc::variant& out) {
+  out = fc::variant{in};
+}
+
+template<enumeration E>
+void to_named_variant(const E& in, const auto& name, fc::variant& out) {
+  out = fc::variant{static_cast<std::underlying_type_t<E>>(in)};
+}
+
+template<reflection T>
+void to_named_variant(const T& in, const auto& name, fc::variant& out) {
+  fc::mutable_variant_object obj;
+  refl::for_each_field(
+    [&](const auto& name_, const auto& value) {
+      fc::variant var;
+      noir::to_named_variant(value, name_, var);
+      obj.set(std::string(name_), var);
+    },
+    in);
+  out = obj;
+}
+
 template<reflection T>
 void to_variant(const T& in, fc::variant& out) {
   fc::mutable_variant_object obj;
-  refl::for_each_field([&](const auto& name, const auto& value) { obj.set(std::string(name), value); }, in);
+  refl::for_each_field(
+    [&](const auto& name, const auto& value) {
+      fc::variant var;
+      noir::to_named_variant(value, name, var);
+      obj.set(std::string(name), var);
+    },
+    in);
   out = obj;
+}
+
+template<typename T>
+void from_named_variant(const fc::variant& in, const auto& name, T& out) {
+  check(!in.is_object());
+  from_variant(in, out);
+}
+
+template<enumeration E>
+void from_named_variant(const fc::variant& in, const auto& name, E& out) {
+  check(!in.is_object());
+  std::underlying_type_t<E> tmp;
+  from_variant(in, tmp);
+  out = static_cast<E>(tmp);
+}
+
+template<reflection T>
+void from_named_variant(const fc::variant& in, const auto& name, T& out) {
+  check(in.is_object());
+  auto obj = in.get_object();
+  refl::for_each_field(
+    [&](const auto& name_, auto& value) { from_named_variant(obj[std::string(name_)], name_, value); }, out);
 }
 
 template<reflection T>
 void from_variant(const fc::variant& in, T& out) {
   check(in.is_object());
   auto obj = in.get_object();
-  refl::for_each_field([&](const auto& name, auto& value) { from_variant(obj[std::string(name)], value); }, out);
+  refl::for_each_field(
+    [&](const auto& name, auto& value) { from_named_variant(obj[std::string(name)], name, value); }, out);
 }
 
 } // namespace noir

--- a/src/noir/consensus/CMakeLists.txt
+++ b/src/noir/consensus/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(noir
   consensus_state.cpp
   merkle/proof.cpp
   merkle/tree.cpp
+  privval/file.cpp
   priv_validator.cpp
   replay.cpp
   validation.cpp
@@ -18,6 +19,7 @@ add_noir_test(bit_array_test test/bit_array_test.cpp)
 add_noir_test(block_executor_test test/block_executor_test.cpp)
 add_noir_test(block_test test/block_test.cpp)
 add_noir_test(consensus_state_test test/consensus_state_test.cpp)
+add_noir_test(privval_test privval/test/file_test.cpp)
 add_noir_test(replay_test test/replay_test.cpp)
 add_noir_test(tree_test merkle/test/tree_test.cpp)
 add_noir_test(validator_test test/validator_test.cpp)

--- a/src/noir/consensus/abci.h
+++ b/src/noir/consensus/abci.h
@@ -37,6 +37,7 @@ public:
     config_->base.mode = Validator; // TODO: read from config or cli
     config_->base.root_dir = appbase::app().home_dir().string();
     config_->consensus.root_dir = config_->base.root_dir;
+    config_->priv_validator.root_dir = config_->base.root_dir;
 
     if (do_not_start_node) {
       // Do not start node, but create an instance of consensus_reactor so network messages can be processed

--- a/src/noir/consensus/abci.h
+++ b/src/noir/consensus/abci.h
@@ -35,6 +35,8 @@ public:
     auto config_ = std::make_shared<config>(config::get_default());
     config_->base.chain_id = "test_chain";
     config_->base.mode = Validator; // TODO: read from config or cli
+    config_->base.root_dir = appbase::app().home_dir().string();
+    config_->consensus.root_dir = config_->base.root_dir;
 
     if (do_not_start_node) {
       // Do not start node, but create an instance of consensus_reactor so network messages can be processed

--- a/src/noir/consensus/common_test.h
+++ b/src/noir/consensus/common_test.h
@@ -46,6 +46,7 @@ config config_setup() {
   config_.base.chain_id = "test_chain";
   config_.base.root_dir = "/tmp/test_consensus";
   config_.consensus.root_dir = config_.base.root_dir;
+  config_.priv_validator.root_dir = config_.base.root_dir;
   return config_;
 }
 

--- a/src/noir/consensus/common_test.h
+++ b/src/noir/consensus/common_test.h
@@ -44,6 +44,8 @@ void increment_height(validator_stub_list& vss, size_t begin_at) {
 config config_setup() {
   auto config_ = config::get_default();
   config_.base.chain_id = "test_chain";
+  config_.base.root_dir = "/tmp/test_consensus";
+  config_.consensus.root_dir = config_.base.root_dir;
   return config_;
 }
 

--- a/src/noir/consensus/config.h
+++ b/src/noir/consensus/config.h
@@ -120,12 +120,48 @@ struct consensus_config {
   }
 };
 
+struct priv_validator_config {
+  std::string root_dir;
+  /// Path to the JSON file containing the private key to use as a validator in the consensus protocol
+  std::string key;
+  /// Path to the JSON file containing the last sign state of a validator
+  std::string state;
+  /// TCP or UNIX socket address for Tendermint to listen on for
+  /// connections from an external PrivValidator process
+  std::string listen_addr;
+
+  /// Client certificate generated while creating needed files for secure connection.
+  /// If a remote validator address is provided but no certificate, the connection will be insecure
+  std::string client_certificate;
+  /// Client key generated while creating certificates for secure connection
+  std::string client_key;
+  /// Path Root Certificate Authority used to sign both client and server certificates
+  std::string root_ca;
+
+  static priv_validator_config get_default() {
+    std::string default_priv_val_key_path =
+      std::string(default_config_dir) + "/" + std::string(default_priv_val_key_name);
+    std::string default_priv_val_state_path =
+      std::string(default_data_dir) + "/" + std::string(default_priv_val_state_name);
+    return {
+      .key = default_priv_val_key_path,
+      .state = default_priv_val_state_path,
+    };
+  }
+
+  static constexpr std::string_view default_config_dir = "config";
+  static constexpr std::string_view default_data_dir = "data";
+  static constexpr std::string_view default_priv_val_key_name = "priv_validator_key.json";
+  static constexpr std::string_view default_priv_val_state_name = "priv_validator_state.json";
+};
+
 struct config {
   base_config base;
   consensus_config consensus;
+  priv_validator_config priv_validator;
 
   static config get_default() {
-    return {base_config::get_default(), consensus_config::get_default()};
+    return {base_config::get_default(), consensus_config::get_default(), priv_validator_config::get_default()};
   }
 };
 
@@ -137,4 +173,4 @@ NOIR_REFLECT(noir::consensus::consensus_config, root_dir, wal_path, wal_file, ti
   timeout_prevote, timeout_prevote_delta, timeout_precommit, timeout_precommit_delta, timeout_commit,
   skip_timeout_commit, create_empty_blocks, create_empty_blocks_interval, peer_gossip_sleep_duration,
   peer_query_maj_23_sleep_duration, double_sign_check_height)
-NOIR_REFLECT(noir::consensus::config, base, consensus)
+NOIR_REFLECT(noir::consensus::config, base, consensus, priv_validator)

--- a/src/noir/consensus/config.h
+++ b/src/noir/consensus/config.h
@@ -83,7 +83,6 @@ struct consensus_config {
 
   static consensus_config get_default() {
     consensus_config cfg;
-    cfg.root_dir = appbase::app().home_dir().string();
     cfg.wal_path = "cs.wal";
     cfg.timeout_propose = std::chrono::milliseconds{3000};
     cfg.timeout_propose_delta = std::chrono::milliseconds{500};

--- a/src/noir/consensus/consensus_state.h
+++ b/src/noir/consensus/consensus_state.h
@@ -33,7 +33,7 @@ struct consensus_state : public std::enable_shared_from_this<consensus_state> {
   state get_state();
   int64_t get_last_height();
   std::shared_ptr<round_state> get_round_state();
-  void set_priv_validator(const priv_validator& priv);
+  void set_priv_validator(const std::shared_ptr<priv_validator>& priv);
   void update_priv_validator_pub_key();
   void reconstruct_last_commit(state& state_);
 
@@ -95,7 +95,7 @@ struct consensus_state : public std::enable_shared_from_this<consensus_state> {
 
   //  privValidator     types.PrivValidator // for signing votes
   //  privValidatorType types.PrivValidatorType
-  std::optional<priv_validator> local_priv_validator;
+  std::shared_ptr<priv_validator> local_priv_validator;
   priv_validator_type local_priv_validator_type;
 
   //  // store blocks and commits

--- a/src/noir/consensus/crypto.h
+++ b/src/noir/consensus/crypto.h
@@ -5,6 +5,7 @@
 //
 #pragma once
 #include <noir/common/hex.h>
+#include <noir/common/refl.h>
 #include <noir/common/types/bytes.h>
 
 #include <fc/crypto/private_key.hpp>
@@ -73,3 +74,6 @@ public:
 };
 
 } // namespace noir::consensus
+
+NOIR_REFLECT(noir::consensus::pub_key, key)
+NOIR_REFLECT(noir::consensus::priv_key, key)

--- a/src/noir/consensus/priv_validator.cpp
+++ b/src/noir/consensus/priv_validator.cpp
@@ -8,7 +8,7 @@
 
 namespace noir::consensus {
 
-std::optional<std::string> priv_validator::sign_vote(vote& vote_) {
+std::optional<std::string> mock_pv::sign_vote(vote& vote_) {
   // TODO: add some validation checks
 
   auto bz = encode(vote_);
@@ -18,7 +18,7 @@ std::optional<std::string> priv_validator::sign_vote(vote& vote_) {
   return {};
 }
 
-std::optional<std::string> priv_validator::sign_proposal(proposal& proposal_) {
+std::optional<std::string> mock_pv::sign_proposal(proposal& proposal_) {
   // TODO: add some validation checks
 
   auto bz = encode(proposal_);

--- a/src/noir/consensus/priv_validator.h
+++ b/src/noir/consensus/priv_validator.h
@@ -18,17 +18,28 @@ enum priv_validator_type {
 };
 
 struct priv_validator {
+  virtual priv_validator_type get_type() const = 0;
+  virtual pub_key get_pub_key() const = 0;
+  virtual priv_key get_priv_key() const = 0;
+  virtual std::optional<std::string> sign_vote(vote& vote_) = 0;
+  virtual std::optional<std::string> sign_proposal(proposal& proposal_) = 0;
+};
+
+struct mock_pv : public priv_validator {
   pub_key pub_key_{};
-  priv_validator_type type{};
+  priv_key priv_key_{};
 
-  priv_key priv_key_{}; // TODO: temp fix; need to implement FilePV, which reads private key from a file
-
-  pub_key get_pub_key() const {
+  priv_validator_type get_type() const override {
+    return priv_validator_type::MockSignerClient;
+  }
+  pub_key get_pub_key() const override {
     return pub_key_;
   }
-
-  std::optional<std::string> sign_vote(vote& vote_);
-  std::optional<std::string> sign_proposal(proposal& proposal_);
+  priv_key get_priv_key() const override {
+    return priv_key_;
+  }
+  std::optional<std::string> sign_vote(vote& vote_) override;
+  std::optional<std::string> sign_proposal(proposal& proposal_) override;
 };
 
 } // namespace noir::consensus

--- a/src/noir/consensus/privval/file.cpp
+++ b/src/noir/consensus/privval/file.cpp
@@ -68,6 +68,12 @@ bool file_pv_last_sign_state::check_hrs(int64_t height_, int32_t round_, sign_st
 void file_pv_last_sign_state::save() {
   check(!file_path.empty(), "cannot save PrivValidator key: filePath not set");
 
+  // FIXME: temporary create lss path dir here
+  fs::path dir_path = fs::path{file_path}.remove_filename();
+  if (!fs::exists(dir_path)) {
+    fs::create_directories(dir_path);
+  }
+
   // TODO: save file in thread safe context (eg.tendermint tempfile)
   // https://pkg.go.dev/github.com/tendermint/tendermint/internal/libs/tempfile
   fc::variant vo;

--- a/src/noir/consensus/privval/file.cpp
+++ b/src/noir/consensus/privval/file.cpp
@@ -1,0 +1,49 @@
+// This file is part of NOIR.
+//
+// Copyright (c) 2022 Haderech Pte. Ltd.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+
+#include <noir/common/check.h>
+#include <noir/consensus/privval/file.h>
+#include <fc/variant_object.hpp>
+
+#include <noir/common/helper/variant.h>
+
+namespace noir::consensus::privval {
+namespace fs = std::filesystem;
+
+void file_pv_key::save() {
+  check(!file_path.empty(), "cannot save PrivValidator key: filePath not set");
+
+  // TODO: save file in thread safe context (eg.tendermint tempfile)
+  // https://pkg.go.dev/github.com/tendermint/tendermint/internal/libs/tempfile
+  fc::variant vo;
+  fc::to_variant<file_pv_key>(*this, vo);
+  fc::json::save_to_file(vo, file_path);
+}
+
+bool file_pv_key::load(const fs::path& key_file_path, file_pv_key& priv_key) {
+  fc::variant obj = fc::json::from_file(key_file_path.string());
+  fc::from_variant(obj, priv_key);
+  priv_key.file_path = key_file_path.string();
+  return true;
+}
+
+void file_pv_last_sign_state::save() {
+  check(!file_path.empty(), "cannot save PrivValidator key: filePath not set");
+  // TODO: save file in thread safe context (eg.tendermint tempfile)
+  // https://pkg.go.dev/github.com/tendermint/tendermint/internal/libs/tempfile
+  fc::variant vo;
+  fc::to_variant<file_pv_last_sign_state>(*this, vo);
+  fc::json::save_to_file(vo, file_path);
+}
+
+bool file_pv_last_sign_state::load(const fs::path& state_file_path, file_pv_last_sign_state& lss) {
+  fc::variant obj = fc::json::from_file(state_file_path.string());
+  fc::from_variant(obj, lss);
+  lss.file_path = state_file_path.string();
+  return true;
+}
+
+} // namespace noir::consensus::privval

--- a/src/noir/consensus/privval/file.cpp
+++ b/src/noir/consensus/privval/file.cpp
@@ -5,13 +5,27 @@
 //
 
 #include <noir/common/check.h>
+#include <noir/common/hex.h>
 #include <noir/consensus/privval/file.h>
 #include <fc/variant_object.hpp>
 
 #include <noir/common/helper/variant.h>
+#include <noir/core/codec.h>
 
 namespace noir::consensus::privval {
 namespace fs = std::filesystem;
+
+sign_step vote_to_step(const noir::consensus::vote& vote) {
+  switch (vote.type) {
+  case noir::p2p::signed_msg_type::Prevote:
+    return sign_step::prevote;
+  case noir::p2p::signed_msg_type::Precommit:
+    return sign_step::precommit;
+  default:
+    check(false, "Unknown vote type: {}", static_cast<int8_t>(vote.type)); // TODO: handle panic
+  }
+  return sign_step::none;
+}
 
 void file_pv_key::save() {
   check(!file_path.empty(), "cannot save PrivValidator key: filePath not set");
@@ -30,8 +44,30 @@ bool file_pv_key::load(const fs::path& key_file_path, file_pv_key& priv_key) {
   return true;
 }
 
+bool file_pv_last_sign_state::check_hrs(int64_t height_, int32_t round_, sign_step step_) const {
+  check(height <= height_, "height regression. Got {}, last height {}", height_, height);
+  if (height == height_) {
+    check(round <= round_, "round regression at height {}. Got {}, last round {}", height_, round_, round);
+    if (round == round_) {
+      check(step <= step_, "step regression at height {} round {}. Got {}, last step {}", height_, round_,
+        static_cast<int8_t>(step_), static_cast<int8_t>(step));
+      if (step == step_) {
+        check(!sign_bytes.empty(), "no sign_bytes found");
+        if (signature.empty()) {
+          // panics if the HRS matches the arguments, there's a SignBytes, but no Signature
+          elog("pv: Signature is nil but sign_bytes is not!");
+          assert(false);
+        }
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 void file_pv_last_sign_state::save() {
   check(!file_path.empty(), "cannot save PrivValidator key: filePath not set");
+
   // TODO: save file in thread safe context (eg.tendermint tempfile)
   // https://pkg.go.dev/github.com/tendermint/tendermint/internal/libs/tempfile
   fc::variant vo;
@@ -84,6 +120,81 @@ std::shared_ptr<file_pv> file_pv::load_file_pv_internal(
 
 void file_pv::save() {
   key.save();
+  last_sign_state.save();
+}
+
+std::string file_pv::string() const {
+  return fmt::format("PrivValidator {} LH:{}, LR:{}, LS:{}", to_hex(key.address), last_sign_state.height,
+    last_sign_state.round, static_cast<int8_t>(last_sign_state.step));
+}
+
+template<typename T>
+bool check_only_differ_by_timestamp(
+  const bytes& last_sign_bytes, const bytes& new_sign_bytes, noir::p2p::tstamp& timestamp) {
+  auto last_vote = decode<T>(last_sign_bytes);
+  auto new_vote = decode<T>(new_sign_bytes);
+  timestamp = last_vote.timestamp;
+  // set the times to the same value and check equality
+  auto now = get_time();
+  last_vote.timestamp = now;
+  new_vote.timestamp = now;
+
+  // FIXME: compare reflected value before encoding
+  auto lhs = encode<T>(last_vote);
+  auto rhs = encode<T>(new_vote);
+  return lhs == rhs;
+}
+
+template<typename T>
+bool sign_internal(T& obj, file_pv& pv, sign_step step) {
+  auto& key = pv.key;
+  auto& lss = pv.last_sign_state;
+  auto height = obj.height;
+  auto round = obj.round;
+
+  auto same_hrs = lss.check_hrs(height, round, step); // throw exception if error
+  auto sign_bytes = encode<T>(obj);
+  p2p::tstamp timestamp;
+
+  // We might crash before writing to the wal,
+  // causing us to try to re-sign for the same HRS.
+  // If signbytes are the same, use the last signature.
+  // If they only differ by timestamp, use last timestamp and signature
+  // Otherwise, return error
+  if (same_hrs) {
+    if (sign_bytes == lss.sign_bytes) {
+      obj.signature = lss.signature;
+    } else if (check_only_differ_by_timestamp<T>(lss.sign_bytes, sign_bytes, timestamp)) {
+      obj.timestamp = timestamp;
+      obj.signature = lss.signature;
+    } else {
+      check(false, "conflicting data");
+      // return false; // TODO: return errors
+    }
+    return true;
+  }
+
+  // It passed the checks. Sign the vote
+  auto sig = key.priv_key.sign(sign_bytes);
+  pv.save_signed(height, round, step, sign_bytes, sig);
+  obj.signature = sig;
+  return true;
+}
+
+bool file_pv::sign_vote_internal(noir::consensus::vote& vote) {
+  return sign_internal<noir::consensus::vote>(vote, *this, vote_to_step(vote));
+}
+
+bool file_pv::sign_proposal_internal(noir::consensus::proposal& proposal) {
+  return sign_internal<noir::consensus::proposal>(proposal, *this, sign_step::propose);
+}
+
+void file_pv::save_signed(int64_t height, int32_t round, sign_step step, const bytes& sign_bytes, const bytes& sig) {
+  last_sign_state.height = height;
+  last_sign_state.round = round;
+  last_sign_state.step = step;
+  last_sign_state.signature = sig;
+  last_sign_state.sign_bytes = sign_bytes;
   last_sign_state.save();
 }
 

--- a/src/noir/consensus/privval/file.h
+++ b/src/noir/consensus/privval/file.h
@@ -1,0 +1,69 @@
+// This file is part of NOIR.
+//
+// Copyright (c) 2022 Haderech Pte. Ltd.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+#pragma once
+
+#include <noir/common/refl.h>
+#include <noir/common/types.h>
+#include <noir/consensus/crypto.h>
+#include <noir/consensus/priv_validator.h>
+#include <fc/io/json.hpp>
+#include <filesystem>
+
+namespace noir::consensus::privval {
+
+/// \addtogroup privval
+/// \ingroup consensus
+/// \{
+
+enum class sign_step : int8_t {
+  none = 0,
+  propose = 1,
+  prevote = 2,
+  precommit = 3,
+};
+
+/// \brief stores the immutable part of PrivValidator.
+struct file_pv_key {
+  bytes address;
+  noir::consensus::pub_key pub_key;
+  noir::consensus::priv_key priv_key;
+  std::string file_path;
+
+  /// \brief Save persists the FilePVKey to its filePath.
+  void save();
+
+  /// \brief loads the immutable part of PrivValidator.
+  /// \param[in] key_file_path
+  /// \param[out] priv_key
+  /// \return
+  static bool load(const std::filesystem::path& key_file_path, file_pv_key& priv_key);
+};
+
+/// \brief FilePVLastSignState stores the mutable part of PrivValidator.
+struct file_pv_last_sign_state {
+  int64_t height;
+  int32_t round;
+  sign_step step;
+  bytes signature;
+  bytes sign_bytes; // hex? bytes?
+  std::string file_path;
+
+  /// \brief persists the FilePvLastSignState to its filePath.
+  void save();
+
+  /// \brief loads the FilePvLastSignState to its filePath.
+  /// \param[in] state_file_path
+  /// \param[out] lss
+  /// \return
+  static bool load(const std::filesystem::path& state_file_path, file_pv_last_sign_state& lss);
+};
+
+/// \}
+
+} // namespace noir::consensus::privval
+
+NOIR_REFLECT(noir::consensus::privval::file_pv_key, address, pub_key, priv_key)
+NOIR_REFLECT(noir::consensus::privval::file_pv_last_sign_state, height, round, step, signature, sign_bytes)

--- a/src/noir/consensus/privval/test/file_test.cpp
+++ b/src/noir/consensus/privval/test/file_test.cpp
@@ -1,0 +1,89 @@
+// This file is part of NOIR.
+//
+// Copyright (c) 2022 Haderech Pte. Ltd.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+
+#include <catch2/catch_all.hpp>
+#include <noir/common/hex.h>
+#include <noir/common/scope_exit.h>
+#include <noir/consensus/privval/file.h>
+#include <noir/crypto/rand.h>
+#include <filesystem>
+
+namespace {
+using namespace noir::consensus::privval;
+namespace fs = std::filesystem;
+
+auto prepare_test_dir = []() {
+  auto temp_dir = std::make_shared<fc::temp_directory>();
+  auto tmp_path = temp_dir->path().string();
+
+  return std::shared_ptr<fc::temp_directory>(std::move(temp_dir));
+};
+
+inline noir::bytes gen_random_bytes(size_t num) {
+  noir::bytes ret(num);
+  noir::crypto::rand_bytes(ret);
+  return ret;
+}
+
+TEST_CASE("priv_val_file: save/load priv_key", "[noir][consensus]") {
+  auto temp_dir = prepare_test_dir();
+  auto temp_dir_path = temp_dir->path().string();
+  auto defer = noir::make_scope_exit([&temp_dir_path]() { fs::remove_all(temp_dir_path); });
+  auto json_file_path = fs::path{temp_dir_path};
+  json_file_path /= "priv_validator_key";
+  json_file_path.replace_extension("json");
+
+  auto exp = file_pv_key{
+    .address = gen_random_bytes(32),
+    .pub_key =
+      {
+        .key = gen_random_bytes(32),
+      },
+    .priv_key =
+      {
+        .key = gen_random_bytes(32),
+      },
+    .file_path = json_file_path,
+  };
+  exp.save();
+
+  file_pv_key ret{};
+  file_pv_key::load(json_file_path, ret);
+
+  CHECK(exp.address == ret.address);
+  CHECK(exp.pub_key == ret.pub_key);
+  CHECK(exp.priv_key == ret.priv_key);
+}
+
+TEST_CASE("priv_val_file: save/load lss", "[noir][consensus]") {
+  auto temp_dir = prepare_test_dir();
+  auto temp_dir_path = temp_dir->path().string();
+  auto defer = noir::make_scope_exit([&temp_dir_path]() { fs::remove_all(temp_dir_path); });
+  auto json_file_path = fs::path{temp_dir_path};
+  json_file_path /= "priv_validator_state";
+  json_file_path.replace_extension("json");
+
+  auto exp = file_pv_last_sign_state{
+    .height = 1,
+    .round = 0,
+    .step = sign_step::none,
+    .signature = gen_random_bytes(32),
+    .sign_bytes = gen_random_bytes(32),
+    .file_path = json_file_path,
+  };
+  exp.save();
+
+  file_pv_last_sign_state ret{};
+  file_pv_last_sign_state::load(json_file_path, ret);
+
+  CHECK(exp.height == ret.height);
+  CHECK(exp.round == ret.round);
+  CHECK(exp.step == ret.step);
+  CHECK(exp.signature == ret.signature);
+  CHECK(exp.sign_bytes == ret.sign_bytes);
+}
+
+} // namespace

--- a/src/noir/consensus/privval/test/file_test.cpp
+++ b/src/noir/consensus/privval/test/file_test.cpp
@@ -95,7 +95,7 @@ TEST_CASE("priv_val_file: save/load lss", "[noir][consensus]") {
   compare_file_pv_last_sign_state(exp, ret);
 }
 
-TEST_CASE("test file_pv", "[priv_val_file]") {
+TEST_CASE("priv_val_file: test file_pv", "[noir][consensus]") {
   auto temp_dir = prepare_test_dir();
   auto temp_dir_path = temp_dir->path().string();
   auto defer = noir::make_scope_exit([&temp_dir_path]() { fs::remove_all(temp_dir_path); });

--- a/src/noir/consensus/privval/test/file_test.cpp
+++ b/src/noir/consensus/privval/test/file_test.cpp
@@ -28,6 +28,21 @@ inline noir::bytes gen_random_bytes(size_t num) {
   return ret;
 }
 
+auto compare_file_pv_key = [](const file_pv_key& exp, const file_pv_key& ret) {
+  CHECK(exp.address == ret.address);
+  CHECK(exp.pub_key == ret.pub_key);
+  CHECK(exp.priv_key == ret.priv_key);
+  CHECK(exp.file_path == ret.file_path);
+};
+
+auto compare_file_pv_last_sign_state = [](const file_pv_last_sign_state& exp, const file_pv_last_sign_state& ret) {
+  CHECK(exp.height == ret.height);
+  CHECK(exp.round == ret.round);
+  CHECK(exp.step == ret.step);
+  CHECK(exp.signature == ret.signature);
+  CHECK(exp.file_path == ret.file_path);
+};
+
 TEST_CASE("priv_val_file: save/load priv_key", "[noir][consensus]") {
   auto temp_dir = prepare_test_dir();
   auto temp_dir_path = temp_dir->path().string();
@@ -53,9 +68,7 @@ TEST_CASE("priv_val_file: save/load priv_key", "[noir][consensus]") {
   file_pv_key ret{};
   file_pv_key::load(json_file_path, ret);
 
-  CHECK(exp.address == ret.address);
-  CHECK(exp.pub_key == ret.pub_key);
-  CHECK(exp.priv_key == ret.priv_key);
+  compare_file_pv_key(exp, ret);
 }
 
 TEST_CASE("priv_val_file: save/load lss", "[noir][consensus]") {
@@ -79,11 +92,72 @@ TEST_CASE("priv_val_file: save/load lss", "[noir][consensus]") {
   file_pv_last_sign_state ret{};
   file_pv_last_sign_state::load(json_file_path, ret);
 
-  CHECK(exp.height == ret.height);
-  CHECK(exp.round == ret.round);
-  CHECK(exp.step == ret.step);
-  CHECK(exp.signature == ret.signature);
-  CHECK(exp.sign_bytes == ret.sign_bytes);
+  compare_file_pv_last_sign_state(exp, ret);
+}
+
+TEST_CASE("test file_pv", "[priv_val_file]") {
+  auto temp_dir = prepare_test_dir();
+  auto temp_dir_path = temp_dir->path().string();
+  auto defer = noir::make_scope_exit([&temp_dir_path]() { fs::remove_all(temp_dir_path); });
+
+  auto key_file_path = fs::path{temp_dir_path};
+  key_file_path /= "priv_validator_key";
+  key_file_path.replace_extension("json");
+
+  auto lss_file_path = fs::path{temp_dir_path};
+  lss_file_path /= "priv_validator_state";
+  lss_file_path.replace_extension("json");
+
+  struct test_case {
+    std::string name;
+    std::string key_type; // TODO: connect key_type
+  };
+  auto tests = std::to_array<struct test_case>({
+    test_case{"priv key_type: secp256k1", "secp256k1"},
+    test_case{"priv key_type: ed25519", "ed25519"},
+  });
+
+  std::for_each(tests.begin(), tests.end(), [&](const test_case& t) {
+    SECTION(t.name) {
+
+      auto file_pv_ptr = file_pv::gen_file_pv(key_file_path, lss_file_path, "secp256k1");
+      REQUIRE(file_pv_ptr != nullptr);
+
+      SECTION("gen_file_pv") {
+        {
+          auto& file_pv_key_ = file_pv_ptr->key;
+          CHECK(file_pv_key_.pub_key.empty() == false);
+          CHECK(file_pv_key_.priv_key.key.empty() == false);
+          CHECK(file_pv_key_.file_path == key_file_path);
+        }
+        {
+          auto& lss = file_pv_ptr->last_sign_state;
+          CHECK(lss.step == sign_step::none);
+          CHECK(lss.file_path == lss_file_path);
+        }
+      }
+
+      file_pv_ptr->save();
+
+      SECTION("load_file_pv_empty_state") {
+        {
+          auto ret = file_pv::load_file_pv_empty_state(key_file_path, lss_file_path);
+          REQUIRE(ret != nullptr);
+          // load_file_pv_empty_state() does not load last_sign_state
+          compare_file_pv_key(ret->key, file_pv_ptr->key);
+        }
+      }
+
+      SECTION("load_file_pv") {
+        {
+          auto ret = file_pv::load_file_pv(key_file_path, lss_file_path);
+          REQUIRE(ret != nullptr);
+          compare_file_pv_key(ret->key, file_pv_ptr->key);
+          compare_file_pv_last_sign_state(ret->last_sign_state, file_pv_ptr->last_sign_state);
+        }
+      }
+    }
+  });
 }
 
 } // namespace

--- a/src/noir/consensus/store/test/block_store_test.cpp
+++ b/src/noir/consensus/store/test/block_store_test.cpp
@@ -14,6 +14,8 @@ namespace {
 static noir::consensus::state make_genesis_state() {
   auto config_ = noir::consensus::config::get_default();
   config_.base.chain_id = "test_block_store";
+  config_.base.root_dir = "/tmp/test_block_store";
+  config_.consensus.root_dir = config_.base.root_dir;
   auto [gen_doc, priv_vals] = noir::consensus::rand_genesis_doc(config_, 1, false, 10);
   return noir::consensus::state::make_genesis_state(gen_doc);
 }

--- a/src/noir/consensus/store/test/block_store_test.cpp
+++ b/src/noir/consensus/store/test/block_store_test.cpp
@@ -16,6 +16,7 @@ static noir::consensus::state make_genesis_state() {
   config_.base.chain_id = "test_block_store";
   config_.base.root_dir = "/tmp/test_block_store";
   config_.consensus.root_dir = config_.base.root_dir;
+  config_.priv_validator.root_dir = config_.base.root_dir;
   auto [gen_doc, priv_vals] = noir::consensus::rand_genesis_doc(config_, 1, false, 10);
   return noir::consensus::state::make_genesis_state(gen_doc);
 }

--- a/src/noir/consensus/test/block_executor_test.cpp
+++ b/src/noir/consensus/test/block_executor_test.cpp
@@ -10,11 +10,11 @@
 using namespace noir;
 using namespace noir::consensus;
 
-std::tuple<state, std::shared_ptr<noir::consensus::db_store>, std::map<std::string, priv_validator>,
+std::tuple<state, std::shared_ptr<noir::consensus::db_store>, std::map<std::string, std::shared_ptr<priv_validator>>,
   std::shared_ptr<noir::db::session::session<noir::db::session::rocksdb_t>>>
 make_state(int n_vals, int height) {
   std::vector<genesis_validator> vals;
-  std::map<std::string, priv_validator> priv_vals;
+  std::map<std::string, std::shared_ptr<priv_validator>> priv_vals;
   for (auto i = 0; i < n_vals; i++) {
     auto [val, priv_val] = rand_validator(false, 1000);
     vals.push_back(genesis_validator{val.address, val.pub_key_, val.voting_power, fmt::format("test#{}", i)});

--- a/src/noir/consensus/test/consensus_state_test.cpp
+++ b/src/noir/consensus/test/consensus_state_test.cpp
@@ -58,7 +58,7 @@ TEST_CASE("consensus_state: No Priv Validator", "[noir][consensus]") {
 TEST_CASE("consensus_state: Verify proposal signature", "[noir][consensus]") {
   auto local_config = config_setup();
   auto [cs1, vss] = rand_cs(local_config, 1);
-  auto local_priv_validator = cs1->local_priv_validator.value();
+  auto local_priv_validator = cs1->local_priv_validator;
 
   proposal proposal_{};
   proposal_.timestamp = get_time();
@@ -66,20 +66,20 @@ TEST_CASE("consensus_state: Verify proposal signature", "[noir][consensus]") {
   auto data_proposal1 = encode((p2p::proposal_message)proposal_);
   // std::cout << "data_proposal1=" << to_hex(data_proposal1) << std::endl;
   // std::cout << "digest1=" << fc::sha256::hash(data_proposal1).str() << std::endl;
-  auto sig_org = local_priv_validator.sign_proposal(proposal_);
+  auto sig_org = local_priv_validator->sign_proposal(proposal_);
   // std::cout << "sig=" << std::string(proposal_.signature.begin(), proposal_.signature.end()) << std::endl;
 
   auto data_proposal2 = encode((p2p::proposal_message)proposal_);
   // std::cout << "data_proposal2=" << to_hex(data_proposal2) << std::endl;
   // std::cout << "digest2=" << fc::sha256::hash(data_proposal2).str() << std::endl;
-  auto result = local_priv_validator.pub_key_.verify_signature(data_proposal2, proposal_.signature);
+  auto result = local_priv_validator->get_pub_key().verify_signature(data_proposal2, proposal_.signature);
   CHECK(result == true);
 }
 
 TEST_CASE("consensus_state: Verify vote signature", "[noir][consensus]") {
   auto local_config = config_setup();
   auto [cs1, vss] = rand_cs(local_config, 1);
-  auto local_priv_validator = cs1->local_priv_validator.value();
+  auto local_priv_validator = cs1->local_priv_validator;
 
   vote vote_{};
   vote_.timestamp = get_time();
@@ -87,12 +87,12 @@ TEST_CASE("consensus_state: Verify vote signature", "[noir][consensus]") {
   auto data_vote1 = encode((p2p::vote_message)vote_);
   // std::cout << "data_vote1=" << to_hex(data_vote1) << std::endl;
   // std::cout << "digest1=" << fc::sha256::hash(data_vote1).str() << std::endl;
-  auto sig_org = local_priv_validator.sign_vote(vote_);
+  auto sig_org = local_priv_validator->sign_vote(vote_);
   // std::cout << "sig=" << std::string(vote_.signature.begin(), vote_.signature.end()) << std::endl;
 
   auto data_vote2 = encode((p2p::vote_message)vote_);
   // std::cout << "data_vote2=" << to_hex(data_vote2) << std::endl;
   // std::cout << "digest2=" << fc::sha256::hash(data_vote2).str() << std::endl;
-  auto result = local_priv_validator.pub_key_.verify_signature(data_vote2, vote_.signature);
+  auto result = local_priv_validator->get_pub_key().verify_signature(data_vote2, vote_.signature);
   CHECK(result == true);
 }


### PR DESCRIPTION
this pr contains feature listed below:
- helper functions to support fc::variants and fc::json (by @conr2d)
- test for helper functions above
- change priv_validator as pure abstract
- create mock_pv which simulates simple priv_validator for test purpose
- create file_pv which loads keys and states from files in root_dir