### PR TITLE
refactor: bytes view

### DIFF
--- a/src/noir/codec/basic_datastream.h
+++ b/src/noir/codec/basic_datastream.h
@@ -18,7 +18,7 @@ class BasicDatastream {
 public:
   BasicDatastream(std::span<T> buf): buf(buf), pos(buf.begin()) {}
   BasicDatastream(T* data, size_t size): BasicDatastream(std::span(data, size)) {}
-  BasicDatastream(BytesViewConstructible auto& buf): BasicDatastream(to_bytes_view(buf)) {}
+  BasicDatastream(BytesViewConstructible auto& buf): BasicDatastream(bytes_view(buf)) {}
 
   auto skip(size_t s) -> Result<void> {
     if (remaining() < s) {

--- a/src/noir/codec/rlp.h
+++ b/src/noir/codec/rlp.h
@@ -15,7 +15,7 @@ NOIR_CODEC(rlp) {
 
 namespace detail {
   template<typename Stream>
-  void encode_bytes(datastream<Stream>& ds, BytesView s, unsigned char mod) {
+  void encode_bytes(datastream<Stream>& ds, std::span<const unsigned char> s, unsigned char mod) {
     auto nonzero = std::find_if(s.rbegin(), s.rend(), [](const auto& c) {
       if (c != 0)
         return true;
@@ -53,7 +53,7 @@ namespace detail {
   }
 
   template<typename Stream>
-  void decode_bytes(datastream<Stream>& ds, BytesViewMut s, unsigned char prefix, unsigned char mod) {
+  void decode_bytes(datastream<Stream>& ds, std::span<unsigned char> s, unsigned char prefix, unsigned char mod) {
     // decode a value less than 128 (0x80)
     if (prefix < 0x80) {
       s[0] = prefix;

--- a/src/noir/common/bytes.h
+++ b/src/noir/common/bytes.h
@@ -69,8 +69,8 @@ public:
     }
   }
 
-  template<typename T>
-  requires(ConvertibleTo<T, BytesView> || BytesViewConstructible<T>) BytesN(T&& bytes, bool canonical = true) {
+  BytesN(auto&& bytes, bool canonical = true) requires(
+    ConvertibleTo<decltype(bytes), std::span<const unsigned char>> || BytesViewConstructible<decltype(bytes)>) {
     if constexpr (N != std::dynamic_extent) {
       auto size = bytes.size();
       if (canonical && size != N) {

--- a/src/noir/crypto/hash/blake2.cpp
+++ b/src/noir/crypto/hash/blake2.cpp
@@ -15,7 +15,7 @@ auto Blake2b256::init() -> Blake2b256& {
   return *this;
 }
 
-auto Blake2b256::update(BytesView in) -> Blake2b256& {
+auto Blake2b256::update(std::span<const unsigned char> in) -> Blake2b256& {
   if (!state) {
     init();
   }
@@ -23,7 +23,7 @@ auto Blake2b256::update(BytesView in) -> Blake2b256& {
   return *this;
 }
 
-void Blake2b256::final(BytesViewMut out) {
+void Blake2b256::final(std::span<unsigned char> out) {
   blake2b_final(&*state, out.data(), digest_size());
 }
 

--- a/src/noir/crypto/hash/blake2.h
+++ b/src/noir/crypto/hash/blake2.h
@@ -17,8 +17,8 @@ struct Blake2b256 : public Hash<Blake2b256> {
   using Hash::update;
 
   auto init() -> Blake2b256&;
-  auto update(BytesView in) -> Blake2b256&;
-  void final(BytesViewMut out);
+  auto update(std::span<const unsigned char> in) -> Blake2b256&;
+  void final(std::span<unsigned char> out);
 
   constexpr auto digest_size() const -> size_t {
     return 32;

--- a/src/noir/crypto/hash/hash.h
+++ b/src/noir/crypto/hash/hash.h
@@ -18,9 +18,7 @@ struct Hash {
   /// \param out output buffer
   void operator()(ByteSequence auto&& in, ByteSequence auto& out) {
     auto derived = static_cast<Derived*>(this);
-    auto in_view = BytesView{byte_pointer_cast(in.data()), in.size()};
-    auto out_view = BytesViewMut{byte_pointer_cast(out.data()), out.size()};
-    derived->init().update(in_view).final(out_view);
+    derived->init().update(bytes_view(in)).final(bytes_view(out));
   }
 
   /// \brief calculates and returns the hash value of input data
@@ -28,20 +26,19 @@ struct Hash {
   /// \return byte array containing hash
   auto operator()(ByteSequence auto&& in) {
     auto derived = static_cast<Derived*>(this);
-    auto in_view = BytesView{byte_pointer_cast(in.data()), in.size()};
-    return derived->init().update(in_view).final();
+    return derived->init().update(bytes_view(in)).final();
   }
 
   /// \brief updates the hash object with byte array
   auto update(BytesViewConstructible auto&& in) -> Derived& {
     auto derived = static_cast<Derived*>(this);
-    return derived->update(to_bytes_view(in));
+    return derived->update(bytes_view(in));
   }
 
   /// \brief stores hash value to output buffer
   void final(BytesViewConstructible auto& out) {
     auto derived = static_cast<Derived*>(this);
-    return derived->update(to_bytes_view(out));
+    derived->final(bytes_view(out));
   }
 
   /// \brief returns hash value

--- a/src/noir/crypto/hash/keccak.cpp
+++ b/src/noir/crypto/hash/keccak.cpp
@@ -17,7 +17,7 @@ auto Keccak256::init() -> Keccak256& {
   return *this;
 }
 
-auto Keccak256::update(BytesView in) -> Keccak256& {
+auto Keccak256::update(std::span<const unsigned char> in) -> Keccak256& {
   if (!ctx) {
     init();
   }
@@ -25,7 +25,7 @@ auto Keccak256::update(BytesView in) -> Keccak256& {
   return *this;
 }
 
-void Keccak256::final(BytesViewMut out) {
+void Keccak256::final(std::span<unsigned char> out) {
   Keccak_HashFinal(&*ctx, (BitSequence*)out.data());
 }
 

--- a/src/noir/crypto/hash/keccak.h
+++ b/src/noir/crypto/hash/keccak.h
@@ -20,8 +20,8 @@ struct Keccak256 : public Hash<Keccak256> {
   using Hash::update;
 
   auto init() -> Keccak256&;
-  auto update(BytesView in) -> Keccak256&;
-  void final(BytesViewMut out);
+  auto update(std::span<const unsigned char> in) -> Keccak256&;
+  void final(std::span<unsigned char> out);
 
   constexpr auto digest_size() const -> size_t {
     return 32;

--- a/src/noir/crypto/hash/ripemd.cpp
+++ b/src/noir/crypto/hash/ripemd.cpp
@@ -249,7 +249,7 @@ auto Ripemd160::Ripemd160::init() -> Ripemd160& {
   return *this;
 }
 
-auto Ripemd160::update(BytesView in) -> Ripemd160& {
+auto Ripemd160::update(std::span<const unsigned char> in) -> Ripemd160& {
   if (!inited) {
     init();
   }
@@ -279,7 +279,7 @@ auto Ripemd160::update(BytesView in) -> Ripemd160& {
   return *this;
 }
 
-void Ripemd160::final(BytesViewMut out) {
+void Ripemd160::final(std::span<unsigned char> out) {
   auto hash = out.data();
   static const unsigned char pad[64] = {0x80};
   unsigned char sizedesc[8];

--- a/src/noir/crypto/hash/ripemd.h
+++ b/src/noir/crypto/hash/ripemd.h
@@ -16,8 +16,8 @@ struct Ripemd160 : public Hash<Ripemd160> {
   using Hash::update;
 
   auto init() -> Ripemd160&;
-  auto update(BytesView in) -> Ripemd160&;
-  void final(BytesViewMut out);
+  auto update(std::span<const unsigned char> in) -> Ripemd160&;
+  void final(std::span<unsigned char> out);
 
   constexpr auto digest_size() const -> size_t {
     return 20;

--- a/src/noir/crypto/hash/sha2.cpp
+++ b/src/noir/crypto/hash/sha2.cpp
@@ -12,7 +12,7 @@ auto Sha256::init() -> Sha256& {
   return *this;
 }
 
-auto Sha256::update(BytesView in) -> Sha256& {
+auto Sha256::update(std::span<const unsigned char> in) -> Sha256& {
   if (!ctx) {
     init();
   }
@@ -20,7 +20,7 @@ auto Sha256::update(BytesView in) -> Sha256& {
   return *this;
 }
 
-void Sha256::final(BytesViewMut out) {
+void Sha256::final(std::span<unsigned char> out) {
   MessageDigest::final(out);
 }
 

--- a/src/noir/crypto/hash/sha2.h
+++ b/src/noir/crypto/hash/sha2.h
@@ -16,8 +16,8 @@ struct Sha256 : public Hash<Sha256>, openssl::MessageDigest {
   using Hash::update;
 
   auto init() -> Sha256&;
-  auto update(BytesView in) -> Sha256&;
-  void final(BytesViewMut out);
+  auto update(std::span<const unsigned char> in) -> Sha256&;
+  void final(std::span<unsigned char> out);
 
   auto digest_size() const -> size_t;
 };

--- a/src/noir/crypto/hash/sha3.cpp
+++ b/src/noir/crypto/hash/sha3.cpp
@@ -15,7 +15,7 @@ auto Sha3_256::init() -> Sha3_256& {
   return *this;
 }
 
-auto Sha3_256::update(BytesView in) -> Sha3_256& {
+auto Sha3_256::update(std::span<const unsigned char> in) -> Sha3_256& {
   if (!ctx) {
     init();
   }
@@ -23,7 +23,7 @@ auto Sha3_256::update(BytesView in) -> Sha3_256& {
   return *this;
 }
 
-void Sha3_256::final(BytesViewMut out) {
+void Sha3_256::final(std::span<unsigned char> out) {
   Keccak_HashFinal(&*ctx, (BitSequence*)out.data());
 }
 

--- a/src/noir/crypto/hash/sha3.h
+++ b/src/noir/crypto/hash/sha3.h
@@ -20,8 +20,8 @@ struct Sha3_256 : public Hash<Sha3_256> {
   using Hash::update;
 
   auto init() -> Sha3_256&;
-  auto update(BytesView in) -> Sha3_256&;
-  void final(BytesViewMut out);
+  auto update(std::span<const unsigned char> in) -> Sha3_256&;
+  void final(std::span<unsigned char> out);
 
   constexpr auto digest_size() const -> size_t {
     return 32;

--- a/src/noir/crypto/hash/xxhash.cpp
+++ b/src/noir/crypto/hash/xxhash.cpp
@@ -15,7 +15,7 @@ auto Xxh64::init() -> Xxh64& {
   return *this;
 }
 
-auto Xxh64::update(BytesView in) -> Xxh64& {
+auto Xxh64::update(std::span<const unsigned char> in) -> Xxh64& {
   if (!state) {
     init();
   }
@@ -23,7 +23,7 @@ auto Xxh64::update(BytesView in) -> Xxh64& {
   return *this;
 }
 
-void Xxh64::final(BytesViewMut out) {
+void Xxh64::final(std::span<unsigned char> out) {
   auto hash = XXH64_digest(&*state);
   std::memcpy(out.data(), (const unsigned char*)&hash, sizeof(decltype(hash)));
 }

--- a/src/noir/crypto/hash/xxhash.h
+++ b/src/noir/crypto/hash/xxhash.h
@@ -18,8 +18,8 @@ struct Xxh64 : public Hash<Xxh64> {
   using Hash::update;
 
   auto init() -> Xxh64&;
-  auto update(BytesView in) -> Xxh64&;
-  void final(BytesViewMut out);
+  auto update(std::span<const unsigned char> in) -> Xxh64&;
+  void final(std::span<unsigned char> out);
   auto final() -> uint64_t;
 
   constexpr auto digest_size() const -> size_t {
@@ -27,7 +27,7 @@ struct Xxh64 : public Hash<Xxh64> {
   }
 
   auto operator()(ByteSequence auto&& in) -> uint64_t {
-    return init().update(to_bytes_view(in)).final();
+    return init().update(bytes_view(in)).final();
   }
 
 private:

--- a/src/noir/crypto/openssl/message_digest.cpp
+++ b/src/noir/crypto/openssl/message_digest.cpp
@@ -20,11 +20,11 @@ void MessageDigest::init(const EVP_MD* type) {
   EVP_DigestInit(ctx, type);
 }
 
-void MessageDigest::update(BytesView in) {
+void MessageDigest::update(std::span<const unsigned char> in) {
   EVP_DigestUpdate(ctx, in.data(), in.size());
 }
 
-void MessageDigest::final(BytesViewMut out) {
+void MessageDigest::final(std::span<unsigned char> out) {
   EVP_DigestFinal(ctx, out.data(), nullptr);
 }
 

--- a/src/noir/crypto/openssl/message_digest.h
+++ b/src/noir/crypto/openssl/message_digest.h
@@ -14,8 +14,8 @@ struct MessageDigest {
   ~MessageDigest();
 
   void init(const EVP_MD* type);
-  void update(BytesView in);
-  void final(BytesViewMut out);
+  void update(std::span<const unsigned char> in);
+  void final(std::span<unsigned char> out);
   size_t digest_size(const EVP_MD* type) const;
 
 protected:

--- a/src/noir/crypto/rand.h
+++ b/src/noir/crypto/rand.h
@@ -11,18 +11,18 @@ namespace noir::crypto {
 
 /// \brief generates random bytes
 /// \ingroup crypto
-Result<void> rand_bytes(BytesViewMut out);
+Result<void> rand_bytes(std::span<unsigned char> out);
 
 Result<void> rand_bytes(BytesViewConstructible auto& out) {
-  return rand_bytes(to_bytes_view(out));
+  return rand_bytes(bytes_view(out));
 }
 
 /// \brief generates random bytes using separated PRNG
 /// \ingroup crypto
-Result<void> rand_priv_bytes(BytesViewMut out);
+Result<void> rand_priv_bytes(std::span<unsigned char> out);
 
 Result<void> rand_priv_bytes(BytesViewConstructible auto& out) {
-  return rand_priv_bytes(to_bytes_view(out));
+  return rand_priv_bytes(bytes_view(out));
 }
 
 } // namespace noir::crypto

--- a/src/noir/crypto/rand/rand.cpp
+++ b/src/noir/crypto/rand/rand.cpp
@@ -10,14 +10,14 @@ namespace noir::crypto {
 
 const auto err_rand_bytes = user_error_registry().register_error("failed to generate random bytes");
 
-Result<void> rand_bytes(BytesViewMut out) {
+Result<void> rand_bytes(std::span<unsigned char> out) {
   if (!RAND_bytes(out.data(), out.size())) {
     return err_rand_bytes;
   }
   return success();
 }
 
-Result<void> rand_priv_bytes(BytesViewMut out) {
+Result<void> rand_priv_bytes(std::span<unsigned char> out) {
   if (!RAND_priv_bytes(out.data(), out.size())) {
     return err_rand_bytes;
   }


### PR DESCRIPTION
- Remove `BytesView`, `BytesViewMut` type aliases
- Rename `to_bytes_view` to `bytes_view`